### PR TITLE
OMXCodec: Remove kClientNeedsFrameBuffer for S3D

### DIFF
--- a/media/libstagefright/OMXCodec.cpp
+++ b/media/libstagefright/OMXCodec.cpp
@@ -2358,9 +2358,6 @@ void OMXCodec::onEvent(OMX_EVENTTYPE event, OMX_U32 data1, OMX_U32 data2) {
 #ifdef USE_S3D_SUPPORT
         case (OMX_EVENTTYPE)OMX_EventS3DInformation:
         {
-            if (mFlags & kClientNeedsFramebuffer)
-                break;
-
             sp<IServiceManager> sm = defaultServiceManager();
             sp<android::IExynosHWCService> hwc = interface_cast<android::IExynosHWCService>(
                     sm->getService(String16("Exynos.HWCService")));


### PR DESCRIPTION
Upstream commit 0bb5ced removed support for this flag.

Reference: https://github.com/CyanogenMod/android_frameworks_av/commit/0bb5ced60304da7f61478ffd359e7ba65d72f181

Change-Id: I56c8c0957b556f70b1a52cd6dd8a2bdd8f958381
